### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build_file: resources
 
 resources: deps
 	@echo "@ Compiling resources into go files ..."
-	@go-bindata -o net/oui_compiled.go -pkg net net/oui.dat
+	@go-bindata -o net/oui_compiled.go -pkg net net/
 
 deps:
 	@echo "@ Installing dependencies ..."


### PR DESCRIPTION
# make
@ Installing dependencies ...
@ Compiling resources into go files ...
bindata: Input path 'net/oui.dat' is not a directory.
Makefile:24: recipe for target 'resources' failed
make: *** [resources] Error 1

And after changing go-bindata -o net/oui_compiled.go -pkg net net/oui.dat to go-bindata -o net/oui_compiled.go -pkg net net/

# make
@ Installing dependencies ...
@ Compiling resources into go files ...
@ Building ...
@ Done