### PR TITLE
Add go-humanize and tablewriter to dependencies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ deps:
 	@go get github.com/robertkrimen/otto
 	@go get github.com/dustin/go-humanize
 	@go get github.com/olekukonko/tablewriter
+	@go get github.com/dustin/go-humanize
+	@go get github.com/olekukonko/tablewriter
 
 clean:
 	@rm -rf $(TARGET) net/oui_compiled.go


### PR DESCRIPTION
Resolves this error:

```shell
$ make
@ Formatting ...
core/build.go
net/oui_compiled.go
@ Running VET ...
@ Compiling resources into go files ...
@ Building ...
session/prompt.go:10:2: cannot find package "github.com/dustin/go-humanize" in any of:
	/snap/go/1016/src/github.com/dustin/go-humanize (from $GOROOT)
	/home/ubuntu/work/src/github.com/dustin/go-humanize (from $GOPATH)
modules/net_recon.go:16:2: cannot find package "github.com/olekukonko/tablewriter" in any of:
	/snap/go/1016/src/github.com/olekukonko/tablewriter (from $GOROOT)
	/home/ubuntu/work/src/github.com/olekukonko/tablewriter (from $GOPATH)
Makefile:12: recipe for target 'build' failed
make: *** [build] Error 1
```