### PR TITLE
Replace net-tools with iproute2

### DIFF
--- a/net/arp_parser_darwin.go
+++ b/net/arp_parser_darwin.go
@@ -4,3 +4,6 @@ import "regexp"
 
 var ArpTableParser = regexp.MustCompile("^[^\\d\\.]+([\\d\\.]+).+\\s+([a-f0-9:]{11,17})\\s+on\\s+([^\\s]+)\\s+.+$")
 var ArpTableTokens = 4
+var ArpTableTokenIndex = []uint{1, 2, 3}
+var ArpCmd = "arp"
+var ArpCmdOpts = []string{"-a", "-n"}

--- a/net/arp_parser_linux.go
+++ b/net/arp_parser_linux.go
@@ -2,5 +2,8 @@ package net
 
 import "regexp"
 
-var ArpTableParser = regexp.MustCompile("^[^\\d\\.]+([\\d\\.]+).+\\s+([a-f0-9:]{17}).+\\s+(.+)$")
+var ArpTableParser = regexp.MustCompile("^([\\d\\.]+)\\s+dev\\s+(\\w+)\\s+\\w+\\s+([a-f0-9:]{17})\\s+\\w+$")
 var ArpTableTokens = 4
+var ArpTableTokenIndex = []uint{1, 3, 2}
+var ArpCmd = "ip"
+var ArpCmdOpts = []string{"neigh"}

--- a/net/arp_unix.go
+++ b/net/arp_unix.go
@@ -12,8 +12,8 @@ func ArpUpdate(iface string) (ArpTable, error) {
 	// Signal we parsed the ARP table at least once.
 	arp_parsed = true
 
-	// Run "arp -an" and parse the output.
-	output, err := core.Exec("arp", []string{"-a", "-n"})
+	// Run "arp -an" (darwin) or "ip neigh" (linux) and parse the output
+	output, err := core.Exec(ArpCmd, ArpCmdOpts)
 	if err != nil {
 		return arp_table, err
 	}
@@ -22,9 +22,9 @@ func ArpUpdate(iface string) (ArpTable, error) {
 	for _, line := range strings.Split(output, "\n") {
 		m := ArpTableParser.FindStringSubmatch(line)
 		if len(m) == ArpTableTokens {
-			address := m[1]
-			mac := m[2]
-			ifname := m[3]
+			address := m[ArpTableTokenIndex[0]]
+			mac := m[ArpTableTokenIndex[1]]
+			ifname := m[ArpTableTokenIndex[2]]
 
 			if ifname == iface {
 				new_table[address] = mac

--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -1,0 +1,20 @@
+package net
+
+import "regexp"
+
+var IPv4RouteParser = regexp.MustCompile("^([a-z]+)+\\s+(\\d+\\.+\\d+.\\d.+\\d)+\\s+([a-zA-z]+)+\\s+(\\d+)+\\s+(\\d+)+\\s+([a-zA-Z]+\\d+)$")
+var IPv4RouteTokens = 7
+var IPv4RouteCmd = "netstat"
+var IPv4RouteCmdOpts = []string{"-n", "-r"}
+
+func IPv4RouteIsGateway(ifname string, tokens []string, f func(gateway string) (*Endpoint, error)) (*Endpoint, error) {
+	ifname2 := tokens[6]
+	flags := tokens[3]
+
+	if ifname == ifname2 && flags == "UGSc" {
+		gateway := tokens[2]
+		return f(gateway)
+	}
+
+	return nil, nil
+}

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -1,0 +1,20 @@
+package net
+
+import "regexp"
+
+// only matches gateway lines
+var IPv4RouteParser = regexp.MustCompile("^(default|[0-9\\.]+)\\svia\\s([0-9\\.]+)\\sdev\\s(\\w+)\\s.*$")
+var IPv4RouteTokens = 4
+var IPv4RouteCmd = "ip"
+var IPv4RouteCmdOpts = []string{"route"}
+
+func IPv4RouteIsGateway(ifname string, tokens []string, f func(gateway string) (*Endpoint, error)) (*Endpoint, error) {
+	ifname2 := tokens[3]
+
+	if ifname == ifname2 {
+		gateway := tokens[2]
+		return f(gateway)
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
Replaced `arp` and `nestat` from `net-tools` package, which are deprecated, by `ip` commands from the newer package `iproute2`.

