### PR TITLE
fix: Cannot parse arp table since MAC addresses are not padded with 0…

### DIFF
--- a/net/arp_parser_darwin.go
+++ b/net/arp_parser_darwin.go
@@ -2,5 +2,5 @@ package net
 
 import "regexp"
 
-var ArpTableParser = regexp.MustCompile("^[^\\d\\.]+([\\d\\.]+).+\\s+([a-f0-9:]{17})\\s+on\\s+([^\\s]+)\\s+.+$")
+var ArpTableParser = regexp.MustCompile("^[^\\d\\.]+([\\d\\.]+).+\\s+([a-f0-9:]{11,17})\\s+on\\s+([^\\s]+)\\s+.+$")
 var ArpTableTokens = 4


### PR DESCRIPTION
… on macOS.

<img width="620" alt="macos_single_char" src="https://user-images.githubusercontent.com/3964394/35216744-b767fde4-ff79-11e7-863c-eb6717cbd965.png">
