### PR TITLE
fix: Arp spoofing poisons other devices although arg.spoof.targets is…

### DIFF
--- a/packets/arp.go
+++ b/packets/arp.go
@@ -1,14 +1,15 @@
 package packets
 
 import (
-	"github.com/google/gopacket/layers"
 	"net"
+
+	"github.com/google/gopacket/layers"
 )
 
 func NewARPTo(from net.IP, from_hw net.HardwareAddr, to net.IP, to_hw net.HardwareAddr, req uint16) (layers.Ethernet, layers.ARP) {
 	eth := layers.Ethernet{
 		SrcMAC:       from_hw,
-		DstMAC:       net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		DstMAC:       to_hw,
 		EthernetType: layers.EthernetTypeARP,
 	}
 	arp := layers.ARP{


### PR DESCRIPTION
… set to a single IP.

Although a target IP is set for arp spoofing, other devices get poisoned. When I analyze the traffic, I can see that bettercap-ng keeps broadcasting ARP replies.I mean target Mac is specified in ARP but not ethernet. This also cause a lot of GARP replies to be sent by colliding endpoint (probably gateway). This pr fixed the issue by sending unicast ARP replies as specified at RFC826.


@evilsocket I don't know If bettercap broadcasts ARP replies on purpose.