### PR TITLE
fix: decimal expected for a float value when printing ticker is runni…

### DIFF
--- a/modules/ticker.go
+++ b/modules/ticker.go
@@ -82,7 +82,7 @@ func (t *Ticker) Start() error {
 
 	t.SetRunning(true)
 	go func() {
-		log.Info("Ticker running with period %ds.", t.Period.Seconds())
+		log.Info("Ticker running with period %.fs.", t.Period.Seconds())
 		tick := time.Tick(t.Period)
 		for _ = range tick {
 			if t.Running() == false {


### PR DESCRIPTION
…ng info text.


<img width="832" alt="ticker1" src="https://user-images.githubusercontent.com/3964394/35553135-a6ef990c-05a7-11e8-8c6f-c831c92c096e.png">
<img width="814" alt="ticker2" src="https://user-images.githubusercontent.com/3964394/35553136-a71defd2-05a7-11e8-81f4-a44b00158726.png">
