### PR TITLE
[feature] net.sniff.http truncate urls option

### DIFF
--- a/modules/net_sniff.go
+++ b/modules/net_sniff.go
@@ -23,6 +23,10 @@ func NewSniffer(s *session.Session) *Sniffer {
 		Stats:         nil,
 	}
 
+	sniff.AddParam(session.NewBoolParameter("net.sniff.truncate",
+		"true",
+		"If true, will truncate long request URLs so user-agent fits on same line when possible, otherwise extra verbose / full URLs."))
+
 	sniff.AddParam(session.NewBoolParameter("net.sniff.verbose",
 		"true",
 		"If true, will print every captured packet, otherwise only selected ones."))
@@ -112,7 +116,7 @@ func (s Sniffer) isLocalPacket(packet gopacket.Packet) bool {
 }
 
 func (s *Sniffer) onPacketMatched(pkt gopacket.Packet) {
-	if mainParser(pkt, s.Ctx.Verbose) == true {
+	if mainParser(pkt, s.Ctx.Verbose, s.Ctx.Truncate) == true {
 		s.Stats.NumDumped++
 	}
 }

--- a/modules/net_sniff_context.go
+++ b/modules/net_sniff_context.go
@@ -16,6 +16,7 @@ import (
 type SnifferContext struct {
 	Handle       *pcap.Handle
 	DumpLocal    bool
+	Truncate     bool
 	Verbose      bool
 	Filter       string
 	Expression   string
@@ -39,6 +40,10 @@ func (s *Sniffer) GetContext() (error, *SnifferContext) {
 	}
 
 	if err, ctx.DumpLocal = s.BoolParam("net.sniff.local"); err != nil {
+		return err, ctx
+	}
+
+	if err, ctx.Truncate = s.BoolParam("net.sniff.truncate"); err != nil {
 		return err, ctx
 	}
 
@@ -77,6 +82,7 @@ func NewSnifferContext() *SnifferContext {
 	return &SnifferContext{
 		Handle:       nil,
 		DumpLocal:    false,
+		Truncate:     true,
 		Verbose:      true,
 		Filter:       "",
 		Expression:   "",
@@ -97,6 +103,12 @@ func (c *SnifferContext) Log(sess *session.Session) {
 		log.Info("Skip local packets : %s", no)
 	} else {
 		log.Info("Skip local packets : %s", yes)
+	}
+
+	if c.Truncate {
+		log.Info("Truncate            : %s", yes)
+	} else {
+		log.Info("Truncate            : %s", no)
 	}
 
 	if c.Verbose {

--- a/modules/net_sniff_parsers.go
+++ b/modules/net_sniff_parsers.go
@@ -10,12 +10,17 @@ import (
 	"github.com/google/gopacket/layers"
 )
 
-func tcpParser(ip *layers.IPv4, pkt gopacket.Packet, verbose bool) {
+func tcpParser(
+	ip *layers.IPv4,
+	pkt gopacket.Packet,
+	verbose bool,
+	truncateURLs bool,
+) {
 	tcp := pkt.Layer(layers.LayerTypeTCP).(*layers.TCP)
 
 	if sniParser(ip, pkt, tcp) {
 		return
-	} else if httpParser(ip, pkt, tcp) {
+	} else if httpParser(ip, pkt, tcp, truncateURLs) {
 		return
 	}
 
@@ -88,7 +93,7 @@ func unkParser(ip *layers.IPv4, pkt gopacket.Packet, verbose bool) {
 	}
 }
 
-func mainParser(pkt gopacket.Packet, verbose bool) bool {
+func mainParser(pkt gopacket.Packet, verbose bool, truncateURLs bool) bool {
 	nlayer := pkt.NetworkLayer()
 	if nlayer == nil {
 		log.Debug("Missing network layer skipping packet.")
@@ -109,7 +114,7 @@ func mainParser(pkt gopacket.Packet, verbose bool) bool {
 	}
 
 	if tlayer.LayerType() == layers.LayerTypeTCP {
-		tcpParser(ip, pkt, verbose)
+		tcpParser(ip, pkt, verbose, truncateURLs)
 	} else if tlayer.LayerType() == layers.LayerTypeUDP {
 		udpParser(ip, pkt, verbose)
 	} else {

--- a/modules/net_sniff_sni.go
+++ b/modules/net_sniff_sni.go
@@ -2,9 +2,9 @@ package modules
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/evilsocket/bettercap-ng/core"
-	"regexp"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
@@ -37,7 +37,7 @@ func sniParser(ip *layers.IPv4, pkt gopacket.Packet, tcp *layers.TCP) bool {
 		ip.SrcIP.String(),
 		domain,
 		SniffData{
-			"Domain": domain,
+			"host": domain,
 		},
 		"[%s] %s %s > %s",
 		vTime(pkt.Metadata().Timestamp),

--- a/modules/net_sniff_views.go
+++ b/modules/net_sniff_views.go
@@ -11,8 +11,10 @@ import (
 	"github.com/evilsocket/bettercap-ng/session"
 )
 
+const sniffTimeFormat = "2006-01-02 15:04:05"
+
 func vTime(t time.Time) string {
-	return t.Format("15:04:05")
+	return t.Format(sniffTimeFormat)
 }
 
 func vIP(ip net.IP) string {


### PR DESCRIPTION
Issues solved in this PR:

New setting: `set net.sniff.truncate <bool>` (default **true**)

- [x] [net.sniff] Add `net.sniff.truncate` setting param in order to toggle shortening / truncating (...) of long URLs in sniffed HTTP requests on demand

> From this: 
[2018-02-04 23:34:58] http local GET meh.ro/static/ro/microsites/meh/css/bootstr... Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36

> To this:
[2018-02-04 23:37:30] http local GET meh.ro/static/ro/microsites/meh/css/bootstrap/bootstrap.min.css Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36

Minor fixes:

- [x] [net.sniff] Make console output consistent - use same timestamp / time format in sniff and events views
- [x] [net.sniff.sni] Use `host` instead of `Domain` in SnifferEvent.SniffData - consistency with net.sniff.http module