### PR TITLE
Revert "[feature] net.sniff.http truncate urls option"

### DIFF
--- a/modules/net_sniff.go
+++ b/modules/net_sniff.go
@@ -23,10 +23,6 @@ func NewSniffer(s *session.Session) *Sniffer {
 		Stats:         nil,
 	}
 
-	sniff.AddParam(session.NewBoolParameter("net.sniff.truncate",
-		"true",
-		"If true, will truncate long request URLs so user-agent fits on same line when possible, otherwise extra verbose / full URLs."))
-
 	sniff.AddParam(session.NewBoolParameter("net.sniff.verbose",
 		"true",
 		"If true, will print every captured packet, otherwise only selected ones."))
@@ -116,7 +112,7 @@ func (s Sniffer) isLocalPacket(packet gopacket.Packet) bool {
 }
 
 func (s *Sniffer) onPacketMatched(pkt gopacket.Packet) {
-	if mainParser(pkt, s.Ctx.Verbose, s.Ctx.Truncate) == true {
+	if mainParser(pkt, s.Ctx.Verbose) == true {
 		s.Stats.NumDumped++
 	}
 }

--- a/modules/net_sniff_context.go
+++ b/modules/net_sniff_context.go
@@ -16,7 +16,6 @@ import (
 type SnifferContext struct {
 	Handle       *pcap.Handle
 	DumpLocal    bool
-	Truncate     bool
 	Verbose      bool
 	Filter       string
 	Expression   string
@@ -40,10 +39,6 @@ func (s *Sniffer) GetContext() (error, *SnifferContext) {
 	}
 
 	if err, ctx.DumpLocal = s.BoolParam("net.sniff.local"); err != nil {
-		return err, ctx
-	}
-
-	if err, ctx.Truncate = s.BoolParam("net.sniff.truncate"); err != nil {
 		return err, ctx
 	}
 
@@ -82,7 +77,6 @@ func NewSnifferContext() *SnifferContext {
 	return &SnifferContext{
 		Handle:       nil,
 		DumpLocal:    false,
-		Truncate:     true,
 		Verbose:      true,
 		Filter:       "",
 		Expression:   "",
@@ -103,12 +97,6 @@ func (c *SnifferContext) Log(sess *session.Session) {
 		log.Info("Skip local packets : %s", no)
 	} else {
 		log.Info("Skip local packets : %s", yes)
-	}
-
-	if c.Truncate {
-		log.Info("Truncate            : %s", yes)
-	} else {
-		log.Info("Truncate            : %s", no)
 	}
 
 	if c.Verbose {

--- a/modules/net_sniff_http.go
+++ b/modules/net_sniff_http.go
@@ -2,9 +2,9 @@ package modules
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/evilsocket/bettercap-ng/core"
+	"regexp"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
@@ -13,12 +13,7 @@ import (
 var httpRe = regexp.MustCompile("(?s).*(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH) (.+) HTTP/\\d\\.\\d.+Host: ([^\\s]+)")
 var uaRe = regexp.MustCompile("(?s).*User-Agent: ([^\\n]+).+")
 
-func httpParser(
-	ip *layers.IPv4,
-	pkt gopacket.Packet,
-	tcp *layers.TCP,
-	truncateURLs bool,
-) bool {
+func httpParser(ip *layers.IPv4, pkt gopacket.Packet, tcp *layers.TCP) bool {
 	data := tcp.Payload
 	dataSize := len(data)
 
@@ -46,12 +41,6 @@ func httpParser(
 	}
 	url += fmt.Sprintf("%s", path)
 
-	// shorten / truncate long URLs if needed
-	formattedURL := string(url)
-	if truncateURLs {
-		formattedURL = vURL(url)
-	}
-
 	NewSnifferEvent(
 		pkt.Metadata().Timestamp,
 		"http",
@@ -68,7 +57,7 @@ func httpParser(
 		core.W(core.BG_RED+core.FG_BLACK, "http"),
 		vIP(ip.SrcIP),
 		core.W(core.BG_LBLUE+core.FG_BLACK, method),
-		formattedURL,
+		vURL(url),
 		core.Dim(ua),
 	).Push()
 

--- a/modules/net_sniff_parsers.go
+++ b/modules/net_sniff_parsers.go
@@ -10,17 +10,12 @@ import (
 	"github.com/google/gopacket/layers"
 )
 
-func tcpParser(
-	ip *layers.IPv4,
-	pkt gopacket.Packet,
-	verbose bool,
-	truncateURLs bool,
-) {
+func tcpParser(ip *layers.IPv4, pkt gopacket.Packet, verbose bool) {
 	tcp := pkt.Layer(layers.LayerTypeTCP).(*layers.TCP)
 
 	if sniParser(ip, pkt, tcp) {
 		return
-	} else if httpParser(ip, pkt, tcp, truncateURLs) {
+	} else if httpParser(ip, pkt, tcp) {
 		return
 	}
 
@@ -93,7 +88,7 @@ func unkParser(ip *layers.IPv4, pkt gopacket.Packet, verbose bool) {
 	}
 }
 
-func mainParser(pkt gopacket.Packet, verbose bool, truncateURLs bool) bool {
+func mainParser(pkt gopacket.Packet, verbose bool) bool {
 	nlayer := pkt.NetworkLayer()
 	if nlayer == nil {
 		log.Debug("Missing network layer skipping packet.")
@@ -114,7 +109,7 @@ func mainParser(pkt gopacket.Packet, verbose bool, truncateURLs bool) bool {
 	}
 
 	if tlayer.LayerType() == layers.LayerTypeTCP {
-		tcpParser(ip, pkt, verbose, truncateURLs)
+		tcpParser(ip, pkt, verbose)
 	} else if tlayer.LayerType() == layers.LayerTypeUDP {
 		udpParser(ip, pkt, verbose)
 	} else {

--- a/modules/net_sniff_sni.go
+++ b/modules/net_sniff_sni.go
@@ -2,9 +2,9 @@ package modules
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/evilsocket/bettercap-ng/core"
+	"regexp"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
@@ -37,7 +37,7 @@ func sniParser(ip *layers.IPv4, pkt gopacket.Packet, tcp *layers.TCP) bool {
 		ip.SrcIP.String(),
 		domain,
 		SniffData{
-			"host": domain,
+			"Domain": domain,
 		},
 		"[%s] %s %s > %s",
 		vTime(pkt.Metadata().Timestamp),

--- a/modules/net_sniff_views.go
+++ b/modules/net_sniff_views.go
@@ -11,10 +11,8 @@ import (
 	"github.com/evilsocket/bettercap-ng/session"
 )
 
-const sniffTimeFormat = "2006-01-02 15:04:05"
-
 func vTime(t time.Time) string {
-	return t.Format(sniffTimeFormat)
+	return t.Format("15:04:05")
 }
 
 func vIP(ip net.IP) string {


### PR DESCRIPTION
Since this information is propagated to events as well as simple logs, truncating the data at the very beginning of the pipeline is a **bad** idea as every other module will have a truncated information.

It'd be rather a visualization option than a module option.