### PR TITLE
fix: Cannot compile because of a missing import.

### DIFF
--- a/network/net_darwin.go
+++ b/network/net_darwin.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"net"
 	"regexp"
 


### PR DESCRIPTION
On macOS, it doesn't compile because fmt is used but not imported.